### PR TITLE
feat: KakaoOAuth를 Credentials Provider를 통해 플로우 개선

### DIFF
--- a/app/api/login-kakao/register/route.ts
+++ b/app/api/login-kakao/register/route.ts
@@ -40,9 +40,11 @@ export async function POST(req: NextRequest) {
 
     const user = await createUser({ provider, providerId, email, username, nickname })
 
-    // TODO: 세션 발급/로그인 상태 설정(NextAuth 또는 커스텀)
+    // 클라이언트에서 NextAuth Credentials Provider로 즉시 로그인 처리
     return NextResponse.json({
+      ok: true,
       success: true,
+      userId: user.userId,
       user: { userId: user.userId, username: user.username, nickname: user.nickname },
     })
   } catch (e: unknown) {

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -144,7 +144,17 @@ function RegisterForm() {
         else setErrors({ form: '회원가입에 실패했습니다. 다시 시도해주세요.' })
         return
       }
-      await signIn('kakao', { callbackUrl: '/' })
+
+      // 회원가입 완료 후 Credentials Provider로 즉시 로그인
+      const result = await signIn('register-complete', {
+        userId: json.userId,
+        callbackUrl: '/',
+        redirect: true,
+      })
+
+      if (result?.error) {
+        setErrors({ form: '로그인 처리에 실패했습니다. 다시 시도해주세요.' })
+      }
     } catch (_e) {
       setErrors({ form: '오류가 발생했습니다. 잠시 후 다시 시도해주세요.' })
     } finally {


### PR DESCRIPTION
## PR 체크리스트

- [x] 코드 변경 사항을 설명하는 커밋 메시지를 작성했습니다.
- [x] 코드 품질을 위한 자체 리뷰를 진행했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 빌드/타입 에러 없음
- [x] ESLint/Prettier 적용 (`pnpm lint`, `pnpm format`)

## 변경 내용 요약

Credentials Provider를 통해 플로우 개선을 통해 중복 SignIn을 예방합니다.

## 영향을 받는 부분

app/api/auth/[...nextauth]/auth-options.ts
app/login/page.tsx
app/api/login-kakao/register/route.ts

## 이슈

resolves #46
